### PR TITLE
fix: Add detailed error logging for report generation

### DIFF
--- a/ai-patient-sim-core-services/simulation-service/src/routes/simulation.js
+++ b/ai-patient-sim-core-services/simulation-service/src/routes/simulation.js
@@ -1927,6 +1927,17 @@ router.get('/:id/report', authMiddleware, async (req, res) => {
 
   } catch (error) {
     console.error('❌ Error generating simulation report:', error);
+    if (axios.isAxiosError(error)) {
+      console.error('Axios error details:', {
+        message: error.message,
+        url: error.config.url,
+        method: error.config.method,
+        response: error.response ? {
+          status: error.response.status,
+          data: error.response.data,
+        } : 'No response',
+      });
+    }
     res.status(500).json({
       success: false,
       error: 'Failed to generate simulation report',


### PR DESCRIPTION
This commit adds more detailed error logging to the report generation route in the simulation service. This will help diagnose the 500 error that was occurring when generating a report. The new logging will capture and display detailed information from Axios errors, including the request URL, method, and response data.