### PR TITLE
fix: Add logging to analytics service

### DIFF
--- a/ai-patient-sim-content-services/analytics-service/api/reports.js
+++ b/ai-patient-sim-content-services/analytics-service/api/reports.js
@@ -97,16 +97,20 @@ const generateMockReport = (simulationId) => {
 };
 
 router.get('/:simulationId', (req, res) => {
+  console.log(`[Analytics Service] Received request for simulation ID: ${req.params.simulationId}`);
   const { simulationId } = req.params;
   if (!simulationId) {
+    console.error('[Analytics Service] Simulation ID is required');
     return res.status(400).json({ success: false, error: 'Simulation ID is required' });
   }
 
   try {
+    console.log(`[Analytics Service] Generating mock report for simulation ID: ${simulationId}`);
     const report = generateMockReport(simulationId);
+    console.log(`[Analytics Service] Successfully generated mock report for simulation ID: ${simulationId}`);
     res.json(report);
   } catch (error) {
-    console.error('Error generating report:', error);
+    console.error('[Analytics Service] Error generating report:', error);
     res.status(500).json({ success: false, error: 'Failed to generate report' });
   }
 });


### PR DESCRIPTION
This commit adds logging to the analytics service to help diagnose the 500 error that is occurring when generating a report. The new logging will trace the request flow through the `reports.js` route handler.